### PR TITLE
Try fixing editable install to meet pep660.

### DIFF
--- a/ihelper/__init__.py
+++ b/ihelper/__init__.py
@@ -8,4 +8,4 @@
 ihelper: A spyder plugin to get help information from ipython console in editor.
 """
 
-__version__ = "0.1"
+__version__ = "0.1.1.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# XXX: If your project needs other packages to build properly, add them to this list.
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import os
 
 def get_version():
     with open("ihelper/__init__.py", encoding='utf-8') as f:
-        lines = [l for l in f.readl().splitlines() if "__version__" in l]
+        lines = [l for l in f.read().splitlines() if "__version__" in l]
         if lines:
             version = lines[0].split("=")[1].strip()
             version = version.replace("'", '').replace('"', '')

--- a/setup.py
+++ b/setup.py
@@ -9,19 +9,25 @@ ihelper: A spyder plugin to get help information from ipython console in editor.
 """
 from setuptools import find_packages
 from setuptools import setup
+import os
 
-# from ihelper import __version__
-
+def get_version():
+    with open("ihelper/__init__.py", encoding='utf-8') as f:
+        lines = [l for l in f.readl().splitlines() if "__version__" in l]
+        if lines:
+            version = lines[0].split("=")[1].strip()
+            version = version.replace("'", '').replace('"', '')
+            return version
 
 setup(
     # See: https://setuptools.readthedocs.io/en/latest/setuptools.html
     name="ihelper",
-    version=0.1,
+    version=get_version(),
     author="gepcel",
     author_email="gepcelway@gmail.com",
     description="A spyder plugin to get help information from ipython console in editor.",
     license="MIT license",
-    url="",
+    url="https://github.com/gepcel/ihelper",
     python_requires='>= 3.7',
     install_requires=[
         "qtpy",


### PR DESCRIPTION
Try fixing the promot when `pip install -e .` Add a pyproject.toml file to meet [PEP660](https://peps.python.org/pep-0660/)

During the installation, there's a msg  as:
```
DEPRECATION: Legacy editable install of ihelper==0.1.1.dev0 from file:/ihelper (setup.py develop) is 
deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml 
or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, 
try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more 
information. Discussion can be found at https://github.com/pypa/pip/issues/11457
```